### PR TITLE
Allow use with Ruby 1.8.x

### DIFF
--- a/scripts/airbrake.check
+++ b/scripts/airbrake.check
@@ -73,8 +73,9 @@ class AirbrakeStatus
   private
 
   def info
-    @errors.each_with_object([]) do |error, result|
+    @errors.inject([]) do |result, error|
       result.concat(error_details(error))
+      result
     end[0..-2]
   end
 


### PR DESCRIPTION
Ruby 1.8 doesn't have #each_with_object on Enumerable.

Using #inject instead.
