### PR TITLE
Add support for authenticated Jenkins builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ If you ever need to kill Checkman:
   checks that all apps are running  
   e.g. `cf_apps.check http://api.cc.com 37jsd-dsjf79-348jdd-fsa88 my-project`
 
-* `jenkins_build.check <JENKINS_URL> <JOB_NAME> [USERNAME] [API_TOKEN]`  
+* `jenkins_build.check <JENKINS_URL> <JOB_NAME> [JENKINS_USER_ID] [API_TOKEN]`  
   checks specific Jenkins build status  
   e.g. `jenkins_build.check https://ci.jenkins-ci.org jenkins_main_trunk`
 
-  Allows for an optional username and API token (or password) if your Jenkins
+  Allows for an optional user ID and API token (or password) if your Jenkins
   instance requires authentication. Specify your full email address as your
-  username if you are using OAuth authentication. Details on obtaining your API
+  user ID if you are using OAuth authentication. Details on obtaining your API
   token can be found
   [here](https://wiki.jenkins-ci.org/display/JENKINS/Authenticating+scripted+clients).
 

--- a/scripts/jenkins_build.check
+++ b/scripts/jenkins_build.check
@@ -144,14 +144,14 @@ class JenkinsJobStatus
 end
 
 class JenkinsJob
-  def initialize(jenkins_url, name, username = nil, api_token = nil)
+  def initialize(jenkins_url, name, user_id = nil, api_token = nil)
     raise ArgumentError "jenkins_url must not be nil" \
       unless @jenkins_url = jenkins_url
 
     raise ArgumentError "name must not be nil" \
       unless @name = name
 
-    @username, @api_token = username, api_token
+    @user_id, @api_token = user_id, api_token
   end
 
   def latest_status
@@ -161,8 +161,8 @@ class JenkinsJob
   private
 
   def authentication_option
-    if @username && @api_token
-      "-u #{@username}:#{@api_token}"
+    if @user_id && @api_token
+      "-u '#{@user_id}:#{@api_token}'"
     end
   end
 


### PR DESCRIPTION
This is a great utility, thanks for the hard work! Sadly I was unable to find it when doing a bit of a search for Jenkins build status indicators. Instead a Pivot pointed it out to me :kissing_heart: :gift_heart:

Anyway I decided to quickly add support for polling Jenkins builds that require OAuth:
- Added 2 optional arguments to Jenkins check script
- Documented 2 new arguments in README.md
