### PR TITLE
scripts: add couchdb.check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,5 @@ script: >
   gem install json &&
   gem install nokogiri -v 1.5.9 &&
   gem install pivotal-tracker &&
+  gem install httparty &&
   LC_CTYPE="en_US.UTF-8" rake

--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ If you ever need to kill Checkman:
   * **Red:** You own a rejected story
   * **Pending:** You haven't started a story
 
+* `couchdb.check <COUCHDB URL>`
+  Checks for active tasks on the CouchDB instance.  The info for the check will show the type and progress of each active task.
+  e.g. `couchdb.check http://localhost:5984`
+  * **Green:** No active tasks
+  * **Pending/Green:** One or more active tasks. All tasks are at least 50% complete.
+  * **Pending/Red:** One or more active tasks is less than 50% complete.
+
 Above scripts are located in `/Applications/Checkman.app/Contents/Resources/`.
 Checkman makes these scripts available by appending stated path to PATH env
 variable when running check commands.

--- a/scripts/couchdb.check
+++ b/scripts/couchdb.check
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+
+require 'httparty'
+require 'json'
+
+class CouchDB
+  def initialize(server)
+    @server = server
+  end
+
+  def latest_status
+    response = HTTParty.get("#{@server}/_active_tasks",
+      headers: {'accept' => 'application/json'})
+
+    tasks = response
+    completions = tasks.map {|t| t['progress'] }
+    info = tasks.map {|t| [t['type'], "#{t['progress']}%"] }
+
+    {
+      result: tasks.size == 0 || completions.min > 50,
+      changing: tasks.size > 0,
+      url: "#{@server}/_utils",
+      info: info
+    }
+  end
+end
+
+puts CouchDB.new(*ARGV).latest_status.to_json if __FILE__ == $0


### PR DESCRIPTION
from the README addition:
- `couchdb.check <COUCHDB URL>`
  Checks for active tasks on the CouchDB instance.  The info for the check will show the type and progress of each active task.
  e.g. `couchdb.check http://localhost:5984`
  - **Green:** No active tasks
  - **Pending/Green:** One or more active tasks. All tasks are at least 50% complete.
  - **Pending/Red:** One or more active tasks is less than 50% complete.
