### PR TITLE
Fix grey builds to show correct color

### DIFF
--- a/scripts/jenkins_build.check
+++ b/scripts/jenkins_build.check
@@ -96,7 +96,7 @@ class JenkinsBuildStatus
   end
 
   def last_commit_short_sha
-    build_action = @build_data["actions"].detect { |a| a["lastBuiltRevision"] }
+    build_action = @build_data["actions"].detect { |a| a != nil && a["lastBuiltRevision"] }
     build_action && build_action["lastBuiltRevision"]["SHA1"][0..5]
   end
 


### PR DESCRIPTION
- In Jenkins, the action array can contain null entries and mask the true (red) color of the build
- This fix gracefully ignores the null entry and moves on to the one with the desired SHA
