### PR TITLE
fix checks for servers that don't support headers only (ex tornado)

### DIFF
--- a/scripts/site.check
+++ b/scripts/site.check
@@ -55,7 +55,7 @@ class Site
   private
 
   def http_get(url)
-    curl = "curl -sIk -A \"CheckmanSite (Hostname: $HOSTNAME)\" '#{url}'"
+    curl = "curl -sik -A \"CheckmanSite (Hostname: $HOSTNAME)\" '#{url}'"
     `#{curl}`.tap { |o| $stderr.puts curl, o }
   end
 end


### PR DESCRIPTION
Tornado endpoints that only implement HTTP GET return a 405 if you do a `curl -I`. This change allows checkman to work for those sites.
