### PR TITLE
If multiple builds are building, correctly find most-recently finished

### DIFF
--- a/scripts/codeship.check
+++ b/scripts/codeship.check
@@ -119,24 +119,24 @@ class CodeshipBuildStatus
     @builds ||= project.builds_in(branch_name)
   end
 
+  def completed_builds
+    builds.reject &:building?
+  end
+
   def most_recent_build
     builds[0]
   end
 
-  def previous_build
-    builds[1]
+  def most_recent_completed_build
+    completed_builds[0]
   end
 
   def successful?
-    if most_recent_build.building? && !previous_build.nil?
-      previous_build.successful?
-    else
-      most_recent_build.successful?
-    end
+    most_recent_completed_build && most_recent_completed_build.successful?
   end
 
   def changing?
-    most_recent_build.building?
+    most_recent_build && most_recent_build.building?
   end
 
   def as_json


### PR DESCRIPTION
I recently noticed that if two builds are in-progress, the checkscript incorrectly reported failure. This pull request fixes that behavior to find the most-recently finished build instead of assuming it's only the first or second build.
