### PR TITLE
Do not blow up if build has not been run [#97554960]

### DIFF
--- a/scripts/jenkins_build.check
+++ b/scripts/jenkins_build.check
@@ -74,7 +74,11 @@ class JenkinsBuildStatus
   end
 
   def console_url
-    @build_data["url"] + "console"
+    if id
+      @build_data["url"] + "console"
+    else
+      @build_data["url"]
+    end
   end
 
   def started_at
@@ -232,11 +236,24 @@ class JenkinsJob
 
   def latest_status
     json = force_utf8(http_get(job_url))
+    parsed_json = JSON.parse(json)
     if @uses_root_api
       JenkinsJobStatuses.from_json(json) \
         .status_for_job(@name)
     else
-      JenkinsJobStatus.from_json(json)
+      if !parsed_json["lastBuild"]
+        parsed_json["lastBuild"] = {
+          "id" => nil,
+          "url" => "#{@jenkins_url}job/#{@name}/",
+          "result" => nil,
+          "fullDisplayName" => nil,
+          "duration" => 0,
+          "timestamp" => 0,
+          "actions" => [],
+          "changeSet" => {"items" => []}
+        }
+      end
+      JenkinsJobStatus.from_json(parsed_json.to_json)
     end
   end
 

--- a/scripts/jenkins_build.check
+++ b/scripts/jenkins_build.check
@@ -243,10 +243,10 @@ class JenkinsJob
     else
       if !parsed_json["lastBuild"]
         parsed_json["lastBuild"] = {
-          "id" => nil,
+          "id" => "N/A",
           "url" => "#{@jenkins_url}job/#{@name}/",
-          "result" => nil,
-          "fullDisplayName" => nil,
+          "result" => false,
+          "fullDisplayName" => "N/A",
           "duration" => 0,
           "timestamp" => 0,
           "actions" => [],


### PR DESCRIPTION
Jenkins build checks were blowing up if build had not been run yet. Change the behavior such that the script successfully completes.