### PR TITLE
Ignore hidden files/folders in subdirectories.

### DIFF
--- a/Checkman/CheckfileCollection.m
+++ b/Checkman/CheckfileCollection.m
@@ -97,6 +97,7 @@
 
     while (fileName = [enumerator nextObject]) {
         if ([fileName characterAtIndex:0] == '.') continue;
+        if ([fileName rangeOfString:@"/."].location != NSNotFound) continue;
         NSString *filePath = F(@"%@/%@", directoryPath, fileName);
 
         BOOL isDirectory = NO;


### PR DESCRIPTION
This allows Checkman to work with submodules